### PR TITLE
fix: Remove invalid '-r' option from mv command

### DIFF
--- a/drv
+++ b/drv
@@ -103,7 +103,7 @@ function drv__install_version()
         return 1
     }
 
-    mv -r $SOURCE $TARGET
+    mv $SOURCE $TARGET
     rm -rf $INSTALL_DIR/tmp
 
     drv__use_version $VERSION


### PR DESCRIPTION
Unless I'm mistaken, GNU mv does not support `-r` as a valid option. This causes the script to fail DragonRuby version installations. Removing the invalid option allows `mv` and the utility to complete successfully.